### PR TITLE
Add markdown linting workflow and documentation navigation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,18 @@ All changes must go through a branch and pull request before merging to main:
 
 Never push directly to the `main` branch.
 
+### Markdown Linting
+
+Run markdownlint on new or edited markdown files before committing:
+
+```bash
+npx markdownlint-cli docs/requirements.md
+npx markdownlint-cli docs/architecture.md
+npx markdownlint-cli **/*.md  # All markdown files
+```
+
+The project uses `.markdownlint.jsonc` for configuration. Fix any reported issues before committing. Files excluded via `.gitignore` do not need to be linted.
+
 ## Key Design Decisions
 
 ### Reliability (Pool Node)

--- a/README.md
+++ b/README.md
@@ -1,64 +1,81 @@
-# Claude Code Python Template
+# Poolio Rearchitect
 
-A Python project template configured for use with Claude Code, following Kent Beck's principles for software development.
+A distributed IoT pool automation and monitoring system being rearchitected from three existing CircuitPython projects.
 
-## Features
+## System Overview
 
-- Poetry for dependency management
-- pytest for testing
-- mypy for type checking
-- ruff for linting and formatting
-- TDD workflow support
-- Claude Code slash commands for PR reviews, issue management, and more
+Poolio automates pool water management:
 
-## Getting Started
+- **Pool Node** - Battery-powered sensor monitoring pool temperature, water level, and battery status
+- **Valve Node** - Controls fill valve based on schedule and water level
+- **Display Node** - TFT touchscreen dashboard showing real-time status
+- **Pump Node** - Variable speed pump control (future)
 
-### Prerequisites
+All nodes communicate via JSON messages over MQTT (Adafruit IO).
 
-- Python 3.11+
-- [Poetry](https://python-poetry.org/docs/#installation)
-
-### Installation
-
-```bash
-poetry install
+```text
+┌─────────────────┐     ┌──────────────────┐     ┌─────────────────┐
+│   Pool Node     │     │   Valve Node     │     │  Display Node   │
+│  (Sensor Unit)  │     │ (Fill Controller)│     │   (Dashboard)   │
+└────────┬────────┘     └────────┬─────────┘     └────────┬────────┘
+         │                       │                        │
+         └───────────────────────┴────────────────────────┘
+                                 │
+                    ┌────────────┴────────────┐
+                    │      Adafruit IO        │
+                    │   (Cloud Message Broker)│
+                    └─────────────────────────┘
 ```
+
+## Documentation
+
+| Document | Purpose |
+|----------|---------|
+| [docs/requirements.md](docs/requirements.md) | Comprehensive system requirements |
+| [docs/architecture.md](docs/architecture.md) | System architecture and implementation details |
+| [CLAUDE.md](CLAUDE.md) | Development guidance for Claude Code |
+
+## Original Projects (Reference)
+
+This rearchitecture consolidates and improves upon:
+
+- `~/source/Poolio-PoolNode` - Original pool sensor
+- `~/source/PoolIO-ValveNode` - Original valve controller
+- `~/source/Poolio-DisplayNode` - Original display dashboard
+
+## Target Hardware
+
+| Node | MCU | Key Components |
+|------|-----|----------------|
+| Pool Node | ESP32 Feather | DS18X20 temp, float switch, LC709203F battery gauge |
+| Valve Node | ESP32-S3 Feather | DS18X20 temp, solenoid valve relay |
+| Display Node | ESP32 Feather | ILI9341 TFT, STMPE610 touch, AHTx0 temp/humidity |
 
 ## Development
 
-### Commands
+See [CLAUDE.md](CLAUDE.md) for detailed development workflow, code standards, and project guidance.
+
+### Quick Start
 
 ```bash
-# Run tests
-poetry run pytest
+# Lint markdown files
+npx markdownlint-cli docs/*.md
 
-# Type checking
-poetry run mypy src/
+# Deploy to CircuitPython device
+rsync -av --exclude='*.pyc' src/pool_node/ /Volumes/CIRCUITPY/
 
-# Linting and formatting
-poetry run ruff check src/ tests/
-poetry run ruff format src/ tests/
+# Monitor serial output
+screen /dev/tty.usbmodem* 115200
 ```
 
-### TDD Workflow
+## Implementation Phases
 
-This project follows Test-Driven Development:
-
-1. **Red** - Write a failing test
-2. **Green** - Write minimal code to pass
-3. **Refactor** - Clean up while tests stay green
-
-## Project Structure
-
-```text
-├── docs/               # Documentation
-└── src/[project_name]/
-    ├── core/           # Core domain logic
-    ├── api/            # API layer
-    ├── services/       # Business logic services
-    ├── models/         # Data models
-    └── utils/          # Utilities
-```
+1. **Foundation** - Shared libraries, JSON messages, cloud abstraction
+2. **Device Framework** - Pool Node, Valve Node, Display Node
+3. **Simulators & Testing** - Node simulators, integration tests
+4. **Deployment** - Nonprod and production environments
+5. **Smart Home** - Homebridge plugin for Apple HomeKit
+6. **Reliability & Polish** - Enhanced error handling, observability
 
 ## License
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -2,6 +2,25 @@
 
 Reverse-engineered from the original PoolIO-ValveNode, Poolio-PoolNode, and Poolio-DisplayNode projects.
 
+## How to Use This Document
+
+| Section | Purpose | Read When... |
+|---------|---------|--------------|
+| 2. Functional Requirements | What each node must do | Implementing node behavior |
+| 3. Non-Functional Requirements | Reliability, security, performance | Implementing error handling, timeouts |
+| 4. Hardware Requirements | MCU and sensor specifications | Setting up physical hardware |
+| 5. Communication Protocol | MQTT feeds, REST endpoints, rate limits | Setting up cloud communication |
+| 6. Configuration Requirements | Settings files and parameters | Configuring nodes |
+| 7.1 Pool Node Reliability | Timeouts, bus recovery, watchdog | Implementing Pool Node |
+| 7.2 JSON Message Format | Message schemas and payloads | Parsing or creating messages |
+| 7.3 Device Extensibility | Adding new device types | Adding pump or other devices |
+| 7.4 HomeKit Integration | Apple Home app support | Implementing Homebridge plugin |
+| 7.5 Environment Configuration | Prod/nonprod setup | Configuring deployment |
+| 7.6-7.7 Architecture & Simulators | Shared libraries, testing tools | Setting up development environment |
+| Appendix A | JSON Schema definitions | Validating messages |
+
+---
+
 ## 1. System Overview
 
 The Poolio system is a distributed IoT pool automation and monitoring platform consisting of three node types that communicate via a cloud-based message broker (Adafruit IO).


### PR DESCRIPTION
## Summary

- Add markdown linting section to CLAUDE.md with `npx markdownlint-cli` commands
- Add "How to Use This Document" section guide to docs/requirements.md for easier navigation
- Replace generic Python template README with Poolio-specific project overview

## Test plan

- [x] All markdown files pass `npx markdownlint-cli`
- [x] VS Code markdownlint plugin uses same config via `.vscode/settings.json`
- [ ] Review section guide in requirements.md for completeness

🤖 Generated with [Claude Code](https://claude.ai/code)