### PR TITLE
feat: Add GitHub Actions CI/CD workflows

### DIFF
--- a/.github/workflows/circuitpython.yml
+++ b/.github/workflows/circuitpython.yml
@@ -1,0 +1,66 @@
+# CircuitPython CI
+# Tests CircuitPython code using Adafruit Blinka compatibility layer
+#
+# Adafruit Blinka provides CircuitPython APIs on CPython, enabling
+# CI testing without hardware. See: https://github.com/adafruit/Adafruit_Blinka
+
+name: CircuitPython
+
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - 'src/**/*.py'
+      - 'tests/**/*.py'
+      - 'requirements*.txt'
+      - 'pyproject.toml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'src/**/*.py'
+      - 'tests/**/*.py'
+      - 'requirements*.txt'
+      - 'pyproject.toml'
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Blinka and dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # Adafruit Blinka - CircuitPython compatibility layer for CPython
+          pip install Adafruit-Blinka
+          # Project dependencies
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+          # Testing tools
+          pip install pytest pytest-cov
+
+      - name: Run tests
+        env:
+          # Tell Blinka we're in a generic Linux environment (no hardware)
+          BLINKA_U2IF: "1"
+        run: |
+          if [ -d "tests" ] && [ "$(find tests -name '*.py' 2>/dev/null | head -1)" ]; then
+            pytest tests/ -v --cov=src --cov-report=term-missing --cov-report=xml
+          else
+            echo "No tests found yet - workflow ready for when tests are added"
+          fi
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v4
+        if: hashFiles('coverage.xml') != ''
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: false

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -1,0 +1,47 @@
+# C++ CI (PlatformIO)
+# Builds and tests ESP32 C++ code for Pool Node
+
+name: C++
+
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - 'pool_node_cpp/**'
+      - 'platformio.ini'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'pool_node_cpp/**'
+      - 'platformio.ini'
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install PlatformIO
+        run: |
+          python -m pip install --upgrade pip
+          pip install platformio
+
+      - name: Build firmware
+        run: pio run -d pool_node_cpp
+
+      - name: Run unit tests
+        run: |
+          # PlatformIO native test runner (runs on host, not device)
+          if pio test -d pool_node_cpp --list-tests 2>/dev/null | grep -q "test"; then
+            pio test -d pool_node_cpp -e native
+          else
+            echo "No native tests configured yet"
+          fi

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -1,0 +1,33 @@
+# Markdown Linting
+# Validates documentation formatting
+
+name: Markdown
+
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - '**/*.md'
+      - '.markdownlint.jsonc'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '**/*.md'
+      - '.markdownlint.jsonc'
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run markdownlint
+        run: npx markdownlint-cli "**/*.md" --ignore node_modules --ignore "**/venv/**" --ignore "**/*-venv/**"

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,45 @@
+# Node.js CI
+# Tests Homebridge plugin for HomeKit integration
+
+name: Node.js
+
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - 'homebridge/**'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'homebridge/**'
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: homebridge
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: homebridge/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint --if-present
+
+      - name: Test
+        run: npm test --if-present
+
+      - name: Build
+        run: npm run build --if-present


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI/CD pipeline with separate workflows for each technology stack
- **markdown.yml**: Lints documentation with markdownlint (active now)
- **circuitpython.yml**: Tests Python code using [Adafruit Blinka](https://github.com/adafruit/Adafruit_Blinka) compatibility layer
- **cpp.yml**: Builds ESP32 firmware with PlatformIO
- **nodejs.yml**: Tests Homebridge plugin

## Details
Each workflow:
- Triggers on push to any branch and PRs to main
- Uses path filters to only run when relevant files change
- Is self-contained and won't fail if target directories don't exist yet

## Test plan
- [ ] Verify markdown workflow runs on this PR
- [ ] Confirm other workflows show as skipped (no matching files yet)
- [ ] Add test files to `src/` and `tests/` to validate CircuitPython workflow activates

🤖 Generated with [Claude Code](https://claude.ai/code)